### PR TITLE
Make the scale-rotate tool's commit behavior more consistent with that of other tools

### DIFF
--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -230,13 +230,10 @@ function main () {
         onChange: e => this.setState({ [key]: parseFloatOrDefault(e.target.value) })
       }
       const rangeProps = {
-        ...props,
-        onMouseDown: () => window.addEventListener('mouseup', this.onMouseCommit)
+        ...props
       }
       const numberProps = {
-        ...props,
-        onKeyUp: this.onKeyCommit,
-        onBlur: this.onCommit
+        ...props
       }
       return e('div', null,
         key,

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name         Line Rider Selection Rotate and Scale Mod
 // @namespace    http://tampermonkey.net/
-// @version      0.4
+// @version      0.5
 // @description  Adds ability to rotate and scale selections
-// @author       David Lu
+// @author       David Lu & Ethan Li
 // @match        https://www.linerider.com/*
 // @match        https://*.official-linerider.com/*
 // @match        http://localhost:8000/*
-// @downloadURL  https://github.com/EmergentStudios/linerider-userscript-mods/raw/master/selection-scale-rotate.user.js
+// @downloadURL  https://github.com/ethanjli/linerider-userscript-mods/raw/master/selection-scale-rotate.user.js
 // @grant        none
 // ==/UserScript==
 

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -162,8 +162,12 @@ class ScaleRotateMod {
   getTransform() {
     const transform = rotateTransform(this.state.rotate * Math.PI / 180)
     transform[0] *= this.state.scale
+    transform[1] *= this.state.scale
+    transform[2] *= this.state.scale
     transform[3] *= this.state.scale
     transform[0] *= this.state.scaleX
+    transform[1] *= this.state.scaleX
+    transform[2] *= this.state.scaleY
     transform[3] *= this.state.scaleY
     return transform
   }

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -238,7 +238,7 @@ function main () {
       return e('div', null,
         key,
         e('input', { style: { width: '3em' }, type: 'number', ...numberProps }),
-        e('input', { type: 'range', ...rangeProps, onFocus: e => e.target.blur() }),
+        e('input', { type: 'range', ...rangeProps, onFocus: e => e.target.blur() })
       )
     }
 

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name         Line Rider Selection Rotate and Scale Mod
 // @namespace    http://tampermonkey.net/
-// @version      0.5
+// @version      0.5.1
 // @description  Adds ability to rotate and scale selections
 // @author       David Lu & Ethan Li
 // @match        https://www.linerider.com/*
 // @match        https://*.official-linerider.com/*
 // @match        http://localhost:8000/*
-// @downloadURL  https://github.com/ethanjli/linerider-userscript-mods/raw/master/selection-scale-rotate.user.js
+// @downloadURL  https://github.com/EmergentStudios/linerider-userscript-mods/raw/master/selection-scale-rotate.user.js
 // @grant        none
 // ==/UserScript==
 
@@ -113,7 +113,7 @@ class ScaleRotateMod {
         this.changed = false
       }
 
-      if (this.state.active && this.selectedPoints.size > 0 && (this.state.scale !== 1 || this.state.scaleX !== 1 || this.state.scaleY !== 1 || this.state.rotate !== 0)) {
+      if (this.state.active && this.selectedPoints.size > 0 && (this.state.scale !== 1 || this.state.scaleX !== 1 || this.state.scaleY !== 1 || this.state.flipX || this.state.flipY || this.state.rotate !== 0)) {
         const selectedLines = [...getLinesFromPoints(this.selectedPoints)]
           .map(id => this.track.getLine(id))
           .filter(l => l)
@@ -168,10 +168,18 @@ class ScaleRotateMod {
     transform[1] *= this.state.scale
     transform[2] *= this.state.scale
     transform[3] *= this.state.scale
-    transform[0] *= this.state.scaleX
-    transform[1] *= this.state.scaleX
-    transform[2] *= this.state.scaleY
-    transform[3] *= this.state.scaleY
+    let scaleX = this.state.scaleX
+    if (this.state.flipX) {
+        scaleX *= -1
+    }
+    let scaleY = this.state.scaleY
+    if (this.state.flipY) {
+        scaleY *= -1
+    }
+    transform[0] *= scaleX
+    transform[1] *= scaleX
+    transform[2] *= scaleY
+    transform[3] *= scaleY
     return transform
   }
 }
@@ -193,6 +201,8 @@ function main () {
         scale: 1,
         scaleX: 1,
         scaleY: 1,
+        flipX: false,
+        flipY: false,
         rotate: 0,
       }
 
@@ -211,6 +221,8 @@ function main () {
           scale: 1,
           scaleX: 1,
           scaleY: 1,
+          flipX: false,
+          flipY: false,
           rotate: 0
         }
         let changedState = {}
@@ -224,6 +236,8 @@ function main () {
           scale: 1,
           scaleX: 1,
           scaleY: 1,
+          flipX: false,
+          flipY: false,
           rotate: 0
         })
       }
@@ -240,6 +254,18 @@ function main () {
         store.dispatch(setTool(SELECT_TOOL))
         this.setState({ active: true })
       }
+    }
+
+    renderCheckbox (key, props) {
+      props = {
+        ...props,
+        checked: this.state[key],
+        onChange: e => this.setState({ [key]: e.target.checked })
+      }
+      return e('div', null,
+        key,
+        e('input', { type: 'checkbox', ...props })
+      )
     }
 
     renderSlider (key, props) {
@@ -266,6 +292,8 @@ function main () {
       return e('div',
         null,
         this.state.active && e('div', null,
+          this.renderCheckbox('flipX', { min: 0, max: 2, step: 0.01 }),
+          this.renderCheckbox('flipY', { min: 0, max: 2, step: 0.01 }),
           this.renderSlider('scaleX', { min: 0, max: 2, step: 0.01 }),
           this.renderSlider('scaleY', { min: 0, max: 2, step: 0.01 }),
           this.renderSlider('scale', { min: 0, max: 2, step: 0.01 }),

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -206,6 +206,18 @@ function main () {
         }
       })
 
+      this.onReset = (key) => {
+        const defaults = {
+          scale: 1,
+          scaleX: 1,
+          scaleY: 1,
+          rotate: 0
+        }
+        let changedState = {}
+        changedState[key] = defaults[key]
+        this.setState(changedState)
+      }
+
       this.onCommit = () => {
         this.scaleRotateMod.commit()
         this.setState({
@@ -245,7 +257,8 @@ function main () {
       return e('div', null,
         key,
         e('input', { style: { width: '3em' }, type: 'number', ...numberProps }),
-        e('input', { type: 'range', ...rangeProps, onFocus: e => e.target.blur() })
+        e('input', { type: 'range', ...rangeProps, onFocus: e => e.target.blur() }),
+        e('button', { onClick: () => this.onReset(key) }, 'Reset')
       )
     }
 

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -239,9 +239,6 @@ function main () {
         key,
         e('input', { style: { width: '3em' }, type: 'number', ...numberProps }),
         e('input', { type: 'range', ...rangeProps, onFocus: e => e.target.blur() }),
-        e('button', { style: { float: 'left' }, onClick: () => this.onCommit() },
-            'Commit'
-        )
       )
     }
 
@@ -252,7 +249,10 @@ function main () {
           this.renderSlider('scaleX', { min: 0, max: 2, step: 0.01 }),
           this.renderSlider('scaleY', { min: 0, max: 2, step: 0.01 }),
           this.renderSlider('scale', { min: 0, max: 2, step: 0.01 }),
-          this.renderSlider('rotate', { min: -180, max: 180, step: 1 })
+          this.renderSlider('rotate', { min: -180, max: 180, step: 1 }),
+          e('button', { style: { float: 'left' }, onClick: () => this.onCommit() },
+              'Commit'
+          )
         ),
         e('button',
           {

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -208,15 +208,6 @@ function main () {
           rotate: 0
         })
       }
-      this.onMouseCommit = () => {
-        this.onCommit()
-        window.removeEventListener('mouseup', this.onMouseCommit)
-      }
-      this.onKeyCommit = e => {
-        if (e.key === 'Enter') {
-          this.onCommit()
-        }
-      }
     }
 
     componentWillUpdate (nextProps, nextState) {
@@ -251,6 +242,9 @@ function main () {
         key,
         e('input', { style: { width: '3em' }, type: 'number', ...numberProps }),
         e('input', { type: 'range', ...rangeProps, onFocus: e => e.target.blur() })
+        e('button', { style: { float: 'left' }, onClick: () => this.onCommit() },
+            'Commit'
+        )
       )
     }
 

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -160,6 +160,9 @@ class ScaleRotateMod {
   }
 
   getTransform() {
+    // The resulting transform is equivalent to the product of a scaling matrix
+    // followed by a rotation matrix. Refer to
+    // https://www.wolframalpha.com/input/?i=%7B%7Bx+*+s%2C+0%7D%2C+%7B0%2C+y+*+s%7D%7D+.+%7B%7Bcos+theta%2C+sin+theta%7D%2C+%7B-sin+theta%2C+cos+theta%7D%7D
     const transform = rotateTransform(this.state.rotate * Math.PI / 180)
     transform[0] *= this.state.scale
     transform[1] *= this.state.scale

--- a/selection-scale-rotate.user.js
+++ b/selection-scale-rotate.user.js
@@ -241,7 +241,7 @@ function main () {
       return e('div', null,
         key,
         e('input', { style: { width: '3em' }, type: 'number', ...numberProps }),
-        e('input', { type: 'range', ...rangeProps, onFocus: e => e.target.blur() })
+        e('input', { type: 'range', ...rangeProps, onFocus: e => e.target.blur() }),
         e('button', { style: { float: 'left' }, onClick: () => this.onCommit() },
             'Commit'
         )


### PR DESCRIPTION
Fixes:
- Change the transformation matrix to be equal to a matrix constructed by right-multiplying a scaling matrix with a rotation matrix (see [here](https://www.wolframalpha.com/input/?i=%7B%7Bx+*+s%2C+0%7D%2C+%7B0%2C+y+*+s%7D%7D+.+%7B%7Bcos+theta%2C+sin+theta%7D%2C+%7B-sin+theta%2C+cos+theta%7D%7D) for a visual representation), so that scaling and rotation parameters can be adjusted simultaneously between commits

Additions/changes:
- Remove the behavior to automatically commit changes in the scale/rotate tool on blur/mouseup/enter events, and instead commit changes only from a new "Commit" button
- Add a reset button for each slider in the tool. The other tools have easy reset, because their sliders can just be dragged all the way to the left. For the scale-rotate tool, the reset positions are in the middle of the sliders - so reset buttons help with usability.
- Add two more tools to the Selection Rotate and Scale Mod, flipX and flipY, which allow mirroring the selection in the x-axis or the y-axis, respectively
- Bump the script's version number from 0.4 to 0.5.1